### PR TITLE
Use scss language service

### DIFF
--- a/e2e/tests/errors.js
+++ b/e2e/tests/errors.js
@@ -37,6 +37,19 @@ describe('Errors', () => {
         });
     });
 
+    it('should not return errors for nested rulesets', () => {
+        const server = createServer();
+        openMockFile(server, mockFileName, 'function css(x) { return x; }; const q = css`&:hover { border: 1px solid black; }`');
+        server.send({ command: 'semanticDiagnosticsSync', arguments: { file: 'main.ts' } });
+
+        return server.close().then(() => {
+            assert.strictEqual(server.responses.length, 3);
+            const errorResponse = server.responses[2];
+            assert.isTrue(errorResponse.success);
+            assert.strictEqual(errorResponse.body.length, 0);
+        });
+    });
+
     it('should not return an error for a placeholder in a property', () => {
         const server = createServer();
         openMockFile(server, mockFileName, 'function css(strings, ...) { return ""; }; const q = css`color: ${"red"};`')

--- a/src/styled-string-language-service.ts
+++ b/src/styled-string-language-service.ts
@@ -4,7 +4,7 @@
 // Original code forked from https://github.com/Quramy/ts-graphql-plugin
 
 import * as ts from 'typescript/lib/tsserverlibrary';
-import { getCSSLanguageService, Stylesheet, LanguageService } from 'vscode-css-languageservice';
+import { getSCSSLanguageService, Stylesheet, LanguageService } from 'vscode-css-languageservice';
 import * as vscode from 'vscode-languageserver-types';
 import { TemplateContext, TemplateStringLanguageService } from './template-string-language-service-proxy';
 import * as config from './config';
@@ -23,7 +23,7 @@ export default class VscodeLanguageServiceAdapter implements TemplateStringLangu
 
     private get languageService(): LanguageService {
         if (!this._languageService) {
-            this._languageService = getCSSLanguageService();
+            this._languageService = getSCSSLanguageService();
             this._languageService.configure(this.configuration);
         }
         return this._languageService;
@@ -73,8 +73,8 @@ export default class VscodeLanguageServiceAdapter implements TemplateStringLangu
     ): vscode.TextDocument {
         contents = `${wrapperPre}${contents}}`;
         return {
-            uri: 'untitled://embedded.css',
-            languageId: 'css',
+            uri: 'untitled://embedded.scss',
+            languageId: 'scss',
             version: 1,
             getText: () => contents,
             positionAt: (offset: number) => {


### PR DESCRIPTION
Use SCSS language service instead of CSS, fixes errors in nested rules. Fixes #2 