### PR TITLE
Fix for https://github.com/Microsoft/typescript-styled-plugin/issues/22

### DIFF
--- a/e2e/tests/errors.js
+++ b/e2e/tests/errors.js
@@ -125,7 +125,7 @@ describe('Errors', () => {
             "  ${mixin};",
             "  color: blue;",
             "`"
-        ]
+        ];
 
         openMockFile(server, mockFileName, lines.join('\n'));
 
@@ -135,6 +135,6 @@ describe('Errors', () => {
             const errorResponse = getFirstResponseOfType('semanticDiagnosticsSync', server);
             assert.isTrue(errorResponse.success);
             assert.strictEqual(errorResponse.body.length, 0);
-        })
+        });
     })
 })

--- a/e2e/tests/errors.js
+++ b/e2e/tests/errors.js
@@ -115,16 +115,33 @@ describe('Errors', () => {
         });
     });
 
-    it('should not error with interpolation at start, followed by semicolon #22', () => {
+    it.only('should not error with interpolation at start, followed by semicolon #22', () => {
         const server = createServer();
 
         const lines = [
             "function css(...args){}",
             "const mixin = ''",
+
+            // test single-line
+            "css`${mixin}; color: blue;`",
+
+            // test multi-line (normal case)
             "css`",
             "  ${mixin};",
             "  color: blue;",
-            "`"
+            "`",
+
+            // test multiple spaces after semi
+            "css`",
+            "  ${mixin}   ;",
+            "  color: blue;",
+            "`",
+
+            // test hella semis - will this ever pop up? probably not, but screw it
+            "css`",
+            "  ${mixin};;; ;; ;",
+            "  color: blue;",
+            "`",
         ];
 
         openMockFile(server, mockFileName, lines.join('\n'));

--- a/e2e/tests/errors.js
+++ b/e2e/tests/errors.js
@@ -115,7 +115,7 @@ describe('Errors', () => {
         });
     });
 
-    it.only('should not error with interpolation at start, followed by semicolon #22', () => {
+    it('should not error with interpolation at start, followed by semicolon #22', () => {
         const server = createServer();
 
         const lines = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,10 +36,18 @@ export = (mod: { typescript: typeof ts }) => {
                     end: number
                 ): string {
                     const placeholder = templateString.slice(start, end);
+
+                    // check to see if it's an in-property interplation, or a mixin,
+                    // and determine which character to use in either case
+                    // if in-property, replace with "xxxxxx"
+                    // if a mixin, replace with "      "
                     const pre = templateString.slice(0, start);
                     const replacementChar = pre.match(/(^|\n)\s*$/g) ? ' ' : 'x';
 
                     let result = placeholder.replace(/./gm, c => c === '\n' ? '\n' : replacementChar);
+
+                    // check if it's a mixin and if followed by a semicolon
+                    // if so, replace with a dummy variable declaration, so scss server doesn't complain about rogue semicolon
                     if (replacementChar === ' ' && templateString.charAt(end) === ';') {
                         result = '$a:0' + result.slice(4);
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,12 @@ export = (mod: { typescript: typeof ts }) => {
                     const placeholder = templateString.slice(start, end);
                     const pre = templateString.slice(0, start);
                     const replacementChar = pre.match(/(^|\n)\s*$/g) ? ' ' : 'x';
-                    return placeholder.replace(/./gm, c => c === '\n' ? '\n' : replacementChar);
+
+                    let result = placeholder.replace(/./gm, c => c === '\n' ? '\n' : replacementChar);
+                    if (replacementChar === ' ' && templateString.charAt(end) === ';') {
+                        result = '$a:0' + result.slice(4);
+                    }
+                    return result;
                 },
             }, { logger });
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export = (mod: { typescript: typeof ts }) => {
 
                     // check if it's a mixin and if followed by a semicolon
                     // if so, replace with a dummy variable declaration, so scss server doesn't complain about rogue semicolon
-                    if (replacementChar === ' ' && templateString.charAt(end) === ';') {
+                    if (replacementChar === ' ' && templateString.slice(end).match(/^\s*;/)) {
                         result = '$a:0' + result.slice(4);
                     }
                     return result;


### PR DESCRIPTION
In the case of a mixin interpolation, uses a dummy SCSS variable declaration to bypass the parser. Not sure if this has unintended side-effects or not.