### PR TITLE
Add 'injectGlobal' as a tag to trigger the plugin

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -9,7 +9,7 @@ export interface TsStyledPluginConfiguration {
 }
 
 export const defaultConfiguration: TsStyledPluginConfiguration = {
-    tags: ['styled', 'css', 'extend'],
+    tags: ['styled', 'css', 'extend', 'injectGlobal'],
     validate: true,
     lint: {
         emptyRules: 'ignore',


### PR DESCRIPTION
The `injectGlobal` function is used by styled-components, emotion (and probably other CSS in JS solutions) to add global CSS. In my opinion it would make sense to support this out of the box.