### PR TITLE
Added support for global style tags

### DIFF
--- a/src/_configuration.ts
+++ b/src/_configuration.ts
@@ -9,7 +9,7 @@ export interface StyledPluginConfiguration {
 }
 
 const defaultConfiguration: StyledPluginConfiguration = {
-    tags: ['styled', 'css', 'extend'],
+    tags: ['styled', 'css', 'extend', 'injectGlobal', 'createGlobalStyle'],
     validate: true,
     lint: {
         emptyRules: 'ignore',


### PR DESCRIPTION
This is based on https://github.com/Microsoft/typescript-styled-plugin/pull/43 but also supports the `createGlobalStyle` tag in the new styled components global style API. Support for `injectGlobal` should still be added for emotion js and older versions of styled components. 