### PR TITLE
Fix error from adjacent variables

### DIFF
--- a/e2e/tests/errors.js
+++ b/e2e/tests/errors.js
@@ -294,5 +294,16 @@ describe('Errors', () => {
             assert.strictEqual(errorResponse.body.length, 0);
         });
     });
+
+    it('should not return an error on adjacent variables (#62)', () => {
+        return getSemanticDiagnosticsForFile(
+            `let css: any = {}; const margin1 = "3px"; const margin2 = "3px"; const q = css.a\`
+                margin: $\{margin1} $\{margin2};
+            \``
+        ).then(errorResponse => {
+            assert.isTrue(errorResponse.success);
+            assert.strictEqual(errorResponse.body.length, 0);
+        });
+    });
 });
 

--- a/src/_substituter.ts
+++ b/src/_substituter.ts
@@ -7,12 +7,20 @@ export function getSubstitutions(
 ): string {
     const parts: string[] = [];
     let lastIndex = 0;
+    const lineStarts = contents
+        .split('\n')
+        .map(line => line.length)
+        .reduce((previousValue, currentValue, currentIndex) => [...previousValue, currentValue + previousValue[currentIndex] + 1], [0]);
+    let lineStartIndex = 0;
     for (const span of spans) {
-        const pre = contents.slice(lastIndex, span.start);
+        while (lineStarts[lineStartIndex] <= span.start) {
+            lineStartIndex++;
+        }
+        const pre = contents.slice(lineStarts[lineStartIndex - 1], span.start);
         const post = contents.slice(span.end);
         const placeholder = contents.slice(span.start, span.end);
 
-        parts.push(pre);
+        parts.push(contents.slice(lastIndex, span.start));
         parts.push(getSubstitution({ pre, placeholder, post }));
         lastIndex = span.end;
     }

--- a/src/test/substituter.test.ts
+++ b/src/test/substituter.test.ts
@@ -145,6 +145,19 @@ describe('substituter', () => {
             ].join('\n')
         );
     });
+
+    it('should replace placeholder that spans multiple lines with x (#44)', () => {
+        assert.deepEqual(
+            performSubstitutions([
+                'background:',
+                `  $\{'transparent'};`,
+            ].join('\n')),
+            [
+                'background:',
+                '  xxxxxxxxxxxxxxxx;',
+            ].join('\n')
+        );
+    });
 });
 
 function performSubstitutions(value: string) {

--- a/src/test/substituter.test.ts
+++ b/src/test/substituter.test.ts
@@ -132,6 +132,19 @@ describe('substituter', () => {
             'color: #000 ;'
         );
     });
+
+    it('should replace adjacent variables with x (#62)', () => {
+        assert.deepEqual(
+            performSubstitutions([
+                `margin: \${'1px'}\${'1px'};`,
+                `padding: \${'1px'} \${'1px'};`,
+            ].join('\n')),
+            [
+                `margin: xxxxxxxxxxxxxxxx;`,
+                `padding: xxxxxxxx xxxxxxxx;`,
+            ].join('\n')
+        );
+    });
 });
 
 function performSubstitutions(value: string) {


### PR DESCRIPTION
## Problem
To solve #62 
The code below will produce an error `warning: '[ts-styled-plugin] semi-colon expected'`.
```js
const Wrapper = styled.div`
  padding: ${spaces.s} ${spaces.l};
`
```
That's because by using `contents.slice(listIndex, span.start)` as `pre`, we couldn't tell the different between ` ${'color: red'};` and the second variable of `margin: ${'1px'} ${'1px'};`. Both of their `pre` are ` `, hence making both of them got replaced by `$a:0   `, which cause an error in the second code (`margin: xxxxxxxx $a:0     ;`).

## Solution
To tell their different, I decided to take a whole line into account as well. I create two types of `pre`, `preTillLineStart` and `preTillLastIndex`, and make sure that both types of `pre` is an empty space. That way we can catch only ` ${'color: red'};` for `$a:0`, not `margin: ${'1px'} ${'1px'};`, not the multi-line case below.
`background:
  ${'black'};`

## Consideration
I haven't fixed the issue caused by the code below, which was reported as a comment in #62 (https://github.com/Microsoft/typescript-styled-plugin/issues/62#issuecomment-413449579). I decided that it's another issue and this PR won't solve that.
```js
styled.div`
  ${Link}:first-child {
    margin: 1px;
  }
`
```