### PR TITLE
Add keyframes to tags by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 0.17.0 - May 05, 2021
+- Apply in `keyframes` by default.
+
 # 0.16.0 - April 28, 2021
 - Pick up new language service version. Thanks @hantatsang and @jasonwilliams!
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Then reload your project to make sure the plugin has been loaded properly. Note 
 ## Configuration
 
 ### Tags
-This plugin adds styled component IntelliSense to any template literal [tagged](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) with `styled`, `css`, `injectGlobal` or `createGlobalStyle`:
+This plugin adds styled component IntelliSense to any template literal [tagged](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) with `styled`, `css`, `injectGlobal`, `keyframes` or `createGlobalStyle`:
 
 ```js
 import styled from 'styled-components'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-styled-plugin",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "TypeScript language service plugin that adds IntelliSense for styled components",
   "keywords": [
     "TypeScript",

--- a/src/_configuration.ts
+++ b/src/_configuration.ts
@@ -11,7 +11,7 @@ export interface StyledPluginConfiguration {
 export class ConfigurationManager {
 
     private static readonly defaultConfiguration: StyledPluginConfiguration = {
-        tags: ['styled', 'css', 'extend', 'injectGlobal', 'createGlobalStyle'],
+        tags: ['styled', 'css', 'extend', 'injectGlobal', 'createGlobalStyle', 'keyframes'],
         validate: true,
         lint: {
             emptyRules: 'ignore',


### PR DESCRIPTION
An issue raised from https://github.com/styled-components/vscode-styled-components/issues/179 requests `keyframes` be added. Its a standard tag in Styled Components so would make sense for it to be added by default.

This PR adds that

@mjbvz 