### PR TITLE
Add intellisense support for keyframes fixes #137

### DIFF
--- a/e2e/project-fixture/tsconfig.json
+++ b/e2e/project-fixture/tsconfig.json
@@ -1,9 +1,7 @@
 {
-  "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
-    "plugins": [
-      { "name": "typescript-styled-plugin", "tags": ["css"] }
-    ]
-  }
+    "compilerOptions": {
+        "target": "es2019",
+        "module": "commonjs",
+        "plugins": [{ "name": "typescript-styled-plugin", "tags": ["css", "keyframes"] }]
+    }
 }

--- a/e2e/tests/completions.js
+++ b/e2e/tests/completions.js
@@ -9,7 +9,7 @@ const createServerWithMockFile = (fileContents) => {
     const server = createServer();
     openMockFile(server, mockFileName, fileContents);
     return server;
-}
+};
 
 describe('Completions', () => {
     it('should return property value completions for single line string', () => {
@@ -20,8 +20,8 @@ describe('Completions', () => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'rgba'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'rgba'));
         });
     });
 
@@ -32,23 +32,19 @@ describe('Completions', () => {
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
-            assert.isFalse(completionsResponse.body.some(item => item.name === 'darken'));
+            assert.isFalse(completionsResponse.body.some((item) => item.name === 'darken'));
         });
     });
 
     it('should return property value completions for multiline string', () => {
-        const server = createServerWithMockFile([
-            'const q = css`',
-            'color:',
-            '`'
-        ].join('\n'));
+        const server = createServerWithMockFile(['const q = css`', 'color:', '`'].join('\n'));
         server.sendCommand('completions', { file: mockFileName, offset: 22, line: 1 });
 
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
@@ -60,7 +56,7 @@ describe('Completions', () => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
@@ -83,7 +79,7 @@ describe('Completions', () => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
@@ -95,19 +91,19 @@ describe('Completions', () => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
     it('should return completions between were placeholders are used as properties', () => {
-        const server = createServerWithMockFile('css`boarder: 1px solid ${"red"}; color: ; margin: ${20}; `')
+        const server = createServerWithMockFile('css`boarder: 1px solid ${"red"}; color: ; margin: ${20}; `');
         server.sendCommand('completions', { file: mockFileName, offset: 40, line: 1 });
 
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
@@ -119,18 +115,18 @@ describe('Completions', () => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
     it('should return js completions inside placeholder', () => {
-        const server = createServerWithMockFile('const abc = 123; css`color: ${};`')
+        const server = createServerWithMockFile('const abc = 123; css`color: ${};`');
         server.sendCommand('completions', { file: mockFileName, offset: 31, line: 1 });
 
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'abc'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'abc'));
         });
     });
 
@@ -141,7 +137,7 @@ describe('Completions', () => {
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'substr'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'substr'));
         });
     });
 
@@ -152,72 +148,55 @@ describe('Completions', () => {
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
     it('should handle multiline value placeholder correctly ', () => {
-        const server = createServerWithMockFile([
-            'css`margin: ${',
-            '0',
-            "}; color: `"].join('\n'));
+        const server = createServerWithMockFile(['css`margin: ${', '0', '}; color: `'].join('\n'));
         server.sendCommand('completions', { file: mockFileName, offset: 10, line: 3 });
 
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
     it('should handle multiline rule placeholder correctly ', () => {
-        const server = createServerWithMockFile([
-            'css`',
-            '${',
-            'css`margin: 0;`',
-            '}',
-            'color: `'].join('\n'));
+        const server = createServerWithMockFile(['css`', '${', 'css`margin: 0;`', '}', 'color: `'].join('\n'));
         server.sendCommand('completions', { file: mockFileName, offset: 8, line: 5 });
 
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
     it('should return completions when placeholder is used as a selector', () => {
-        const server = createServerWithMockFile([
-            'css`${"button"} {',
-            '   color: ;',
-            '}',
-            'color: ;',
-            '`'].join('\n'));
+        const server = createServerWithMockFile(['css`${"button"} {', '   color: ;', '}', 'color: ;', '`'].join('\n'));
         server.sendCommand('completions', { file: mockFileName, line: 2, offset: 11 });
 
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
     it('should return completions inside of nested selector xx', () => {
-        const server = createServerWithMockFile([
-            'css`',
-            '    color: red;',
-            '    &:hover {',
-            '        color:   ',
-            '    }',
-            '`'].join('\n'));
+        const server = createServerWithMockFile(
+            ['css`', '    color: red;', '    &:hover {', '        color:   ', '    }', '`'].join('\n')
+        );
         server.sendCommand('completions', { file: mockFileName, line: 4, offset: 15 });
 
         return server.close().then(() => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
         });
     });
 
@@ -229,8 +208,8 @@ describe('Completions', () => {
             const completionsResponse = getFirstResponseOfType('completions', server);
             assert.isTrue(completionsResponse.success);
             assert.strictEqual(completionsResponse.body.length, 157);
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
-            assert.isTrue(completionsResponse.body.some(item => item.name === 'rgba'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
+            assert.isTrue(completionsResponse.body.some((item) => item.name === 'rgba'));
         });
     });
 
@@ -242,8 +221,8 @@ describe('Completions', () => {
         const completionsResponse = getFirstResponseOfType('completions', server);
         assert.isTrue(completionsResponse.success);
         assert.strictEqual(completionsResponse.body.length, 157);
-        assert.isTrue(completionsResponse.body.some(item => item.name === 'aliceblue'));
-        assert.isTrue(completionsResponse.body.some(item => item.name === 'rgba'));
+        assert.isTrue(completionsResponse.body.some((item) => item.name === 'aliceblue'));
+        assert.isTrue(completionsResponse.body.some((item) => item.name === 'rgba'));
     });
 
     it('should mark color completions with "color" kindModifier', async () => {
@@ -253,7 +232,18 @@ describe('Completions', () => {
         await server.close();
         const completionsResponse = getFirstResponseOfType('completions', server);
         assert.isTrue(completionsResponse.success);
-        const aliceBlue = completionsResponse.body.find(item => item.name === 'aliceblue');
+        const aliceBlue = completionsResponse.body.find((item) => item.name === 'aliceblue');
+        assert.isTrue(aliceBlue.kindModifiers === 'color');
+    });
+
+    it('should get completions inside keyframes blocks', async () => {
+        const server = createServerWithMockFile('const q = keyframes`0% {color:`');
+        server.sendCommand('completions', { file: mockFileName, offset: 31, line: 1 });
+
+        await server.close();
+        const completionsResponse = getFirstResponseOfType('completions', server);
+        assert.isTrue(completionsResponse.success);
+        const aliceBlue = completionsResponse.body.find((item) => item.name === 'aliceblue');
         assert.isTrue(aliceBlue.kindModifiers === 'color');
     });
 });

--- a/src/_virtual-document-provider.ts
+++ b/src/_virtual-document-provider.ts
@@ -27,7 +27,7 @@ export class StyledVirtualDocumentFactory implements VirtualDocumentProvider {
     public createVirtualDocument(
         context: TemplateContext
     ): vscode.TextDocument {
-        const contents = `${this.getVirtualDocumentRoot(context)}${context.text}}`;
+        const contents = `${this.getVirtualDocumentWrapper(context)}${context.text}}`;
         return {
             uri: 'untitled://embedded.scss',
             languageId: 'scss',
@@ -60,14 +60,14 @@ export class StyledVirtualDocumentFactory implements VirtualDocumentProvider {
     }
 
     public toVirtualDocOffset(offset: number, context: TemplateContext): number {
-        return offset + this.getVirtualDocumentRoot(context).length;
+        return offset + this.getVirtualDocumentWrapper(context).length;
     }
 
     public fromVirtualDocOffset(offset: number, context: TemplateContext): number {
-        return offset - this.getVirtualDocumentRoot(context).length;
+        return offset - this.getVirtualDocumentWrapper(context).length;
     }
 
-    private getVirtualDocumentRoot(context: TemplateContext): string {
+    private getVirtualDocumentWrapper(context: TemplateContext): string {
         const tag = (context.node.parent as ts.Node & { tag: any })?.tag?.escapedText;
         return tag === 'keyframes' ? StyledVirtualDocumentFactory.wrapperPreKeyframes : StyledVirtualDocumentFactory.wrapperPreRoot;
     }

--- a/src/_virtual-document-provider.ts
+++ b/src/_virtual-document-provider.ts
@@ -27,7 +27,7 @@ export class StyledVirtualDocumentFactory implements VirtualDocumentProvider {
     public createVirtualDocument(
         context: TemplateContext
     ): vscode.TextDocument {
-        const contents = `${this.getVirtualDocumentWrapper(context)}${context.text}}`;
+        const contents = `${this.getVirtualDocumentWrapper(context)}${context.text}\n}`;
         return {
             uri: 'untitled://embedded.scss',
             languageId: 'scss',

--- a/src/_virtual-document-provider.ts
+++ b/src/_virtual-document-provider.ts
@@ -10,8 +10,8 @@ export interface VirtualDocumentProvider {
     createVirtualDocument(context: TemplateContext): vscode.TextDocument;
     toVirtualDocPosition(position: ts.LineAndCharacter): ts.LineAndCharacter;
     fromVirtualDocPosition(position: ts.LineAndCharacter): ts.LineAndCharacter;
-    toVirtualDocOffset(offset: number): number;
-    fromVirtualDocOffset(offset: number): number;
+    toVirtualDocOffset(offset: number, context: TemplateContext): number;
+    fromVirtualDocOffset(offset: number, context: TemplateContext): number;
 }
 
 /**
@@ -21,24 +21,25 @@ export interface VirtualDocumentProvider {
  * since styled allows properties to be top level elements.
  */
 export class StyledVirtualDocumentFactory implements VirtualDocumentProvider {
-    private static readonly wrapperPre = ':root{\n';
+    private static readonly wrapperPreRoot = ':root{\n';
+    private static readonly wrapperPreKeyframes = '@keyframes custom {\n';
 
     public createVirtualDocument(
         context: TemplateContext
     ): vscode.TextDocument {
-        const contents = `${StyledVirtualDocumentFactory.wrapperPre}${context.text}\n}`;
+        const contents = `${this.getVirtualDocumentRoot(context)}${context.text}}`;
         return {
             uri: 'untitled://embedded.scss',
             languageId: 'scss',
             version: 1,
             getText: () => contents,
             positionAt: (offset: number) => {
-                const pos = context.toPosition(this.fromVirtualDocOffset(offset));
+                const pos = context.toPosition(this.fromVirtualDocOffset(offset, context));
                 return this.toVirtualDocPosition(pos);
             },
             offsetAt: (p: vscode.Position) => {
                 const offset = context.toOffset(this.fromVirtualDocPosition(p));
-                return this.toVirtualDocOffset(offset);
+                return this.toVirtualDocOffset(offset, context);
             },
             lineCount: contents.split(/\n/g).length + 1,
         };
@@ -58,11 +59,16 @@ export class StyledVirtualDocumentFactory implements VirtualDocumentProvider {
         };
     }
 
-    public toVirtualDocOffset(offset: number): number {
-        return offset + StyledVirtualDocumentFactory.wrapperPre.length;
+    public toVirtualDocOffset(offset: number, context: TemplateContext): number {
+        return offset + this.getVirtualDocumentRoot(context).length;
     }
 
-    public fromVirtualDocOffset(offset: number): number {
-        return offset - StyledVirtualDocumentFactory.wrapperPre.length;
+    public fromVirtualDocOffset(offset: number, context: TemplateContext): number {
+        return offset - this.getVirtualDocumentRoot(context).length;
+    }
+
+    private getVirtualDocumentRoot(context: TemplateContext): string {
+        const tag = (context.node.parent as ts.Node & { tag: any })?.tag?.escapedText;
+        return tag === 'keyframes' ? StyledVirtualDocumentFactory.wrapperPreKeyframes : StyledVirtualDocumentFactory.wrapperPreRoot;
     }
 }


### PR DESCRIPTION
- Dynamically set the wrapper to be `@keyframes {}` when the keyframes tag is used
- Pass context to offset functions so  they can calculate the correct wrapper length
- This uses a new utility function which will return the correct wrapper based on the context used.
- Update target output for TS
 - Add keyframes test for completions
 - Prettier

Fixes https://github.com/microsoft/typescript-styled-plugin/issues/137
Fixes #136
@mjbvz 

![keyframes](https://user-images.githubusercontent.com/936006/119698453-2a823b00-be49-11eb-8493-44c37c69072f.gif)
