### PR TITLE
Send replacement spans in response, fixes a whole class of issues

### DIFF
--- a/src/_language-service.ts
+++ b/src/_language-service.ts
@@ -423,6 +423,7 @@ function translateCompetionEntry(
         kindModifiers: getKindModifiers(item),
         sortText: item.sortText || item.label,
         replacementSpan: {
+            // The correct offset for start seems to be the range.start minus the wrapper
             start: doc.offsetAt((item as any).textEdit.range.start) - wrapper.length,
             length: doc.offsetAt((item as any).textEdit.range.end) - doc.offsetAt((item as any).textEdit.range.start),
         },

--- a/src/_virtual-document-provider.ts
+++ b/src/_virtual-document-provider.ts
@@ -12,6 +12,7 @@ export interface VirtualDocumentProvider {
     fromVirtualDocPosition(position: ts.LineAndCharacter): ts.LineAndCharacter;
     toVirtualDocOffset(offset: number, context: TemplateContext): number;
     fromVirtualDocOffset(offset: number, context: TemplateContext): number;
+    getVirtualDocumentWrapper(context: TemplateContext): string;
 }
 
 /**
@@ -67,7 +68,7 @@ export class StyledVirtualDocumentFactory implements VirtualDocumentProvider {
         return offset - this.getVirtualDocumentWrapper(context).length;
     }
 
-    private getVirtualDocumentWrapper(context: TemplateContext): string {
+    public getVirtualDocumentWrapper(context: TemplateContext): string {
         const tag = (context.node.parent as ts.Node & { tag: any })?.tag?.escapedText;
         return tag === 'keyframes' ? StyledVirtualDocumentFactory.wrapperPreKeyframes : StyledVirtualDocumentFactory.wrapperPreRoot;
     }


### PR DESCRIPTION
Well that was a long journey....
But I think I've managed to fix it.

https://user-images.githubusercontent.com/936006/142737306-0e1333d8-867d-40dc-a704-5ca4372af1ce.mp4

After some [long debugging](https://github.com/microsoft/vscode/issues/134328#issuecomment-974200861) I was able to see that `replacementSpan`s weren't being sent to VSCode. Causing VSCode falling back to defaultSpans which weren't very good. Basically it was falling back to appending the value on the end instead of replacing the word left of the cursor. This problem is 2-fold because VSCode uses the replacement span information to know how to filter-down the results the language server sends. So results in the UI were also bad because of there being no spans

The offset being sent was wrong, I was able to figure out that it was off by 7 characters which coincidently is the same length of the document wrapper, so I have deducted that which gives much better results.

Fixes: https://github.com/styled-components/vscode-styled-components/issues/322
Fixes: https://github.com/microsoft/vscode/issues/134328#issuecomment-974200861
Fixes: https://github.com/styled-components/vscode-styled-components/issues/325
Fixes: https://github.com/styled-components/vscode-styled-components/issues/302
Fixes: https://github.com/microsoft/typescript-styled-plugin/issues/155
Fixes: https://github.com/microsoft/typescript-styled-plugin/issues/141
Fixes: https://github.com/microsoft/typescript-styled-plugin/issues/153

I need a lie down now

@mjbvz hopefully you can take a look at this

